### PR TITLE
Re enable option redirect.doubleoptin

### DIFF
--- a/de.locallang_db.xlf
+++ b/de.locallang_db.xlf
@@ -211,6 +211,10 @@
 				<source>Redirect Site ID &quot;Registration&quot;:</source>
 				<target>Weiterleitungsseiten ID &quot;Registrierung&quot;:</target>
 			</trans-unit>
+			<trans-unit id="tt_content.pi_flexform.redirect.doubleoptin" xml:space="preserve" approved="yes">
+				<source>Redirect Site ID &quot;Double Opt-in&quot; (fallback):</source>
+				<target>Weiterleitungsseiten ID &quot;Double-Opt-In&quot; (Plan B):</target>
+			</trans-unit>
 			<trans-unit id="tt_content.pi_flexform.redirect.doubleoptin_success" xml:space="preserve" approved="yes">
 				<source>Redirect Site ID &quot;Double Opt-in - Activated&quot;:</source>
 				<target>Weiterleitungsseiten ID &quot;Double-Opt-In - Aktiviert&quot;:</target>

--- a/flexform/sheet_redirect.xml
+++ b/flexform/sheet_redirect.xml
@@ -35,6 +35,34 @@
 				</TCEforms>
 			</redirect.register_success>
 
+			<redirect.doubleoptin>
+				<TCEforms>
+					<label>LLL:EXT:datamints_feuser/locallang_db.xml:tt_content.pi_flexform.redirect.doubleoptin</label>
+					<config>
+						<type>input</type>
+						<size>5</size>
+						<max>100</max>
+						<eval>int</eval>
+						<wizards type="array">
+							<_PADDING type="integer">2</_PADDING>
+							<link type="array">
+								<type>popup</type>
+								<title>LLL:EXT:datamints_feuser/locallang_db.xml:tt_content.pi_flexform.redirect.doubleoptin</title>
+								<icon>link_popup.gif</icon>
+								<module type="array">
+									<name>wizard_element_browser</name>
+									<urlParameters type="array">
+										<mode>wizard</mode>
+										<act>file</act>
+									</urlParameters>
+								</module>
+								<JSopenParams>height=600,width=500,status=0,menubar=0,scrollbars=1</JSopenParams>
+							</link>
+						</wizards>
+					</config>
+				</TCEforms>
+			</redirect.doubleoptin>
+
 			<redirect.doubleoptin_success>
 				<TCEforms>
 					<label>LLL:EXT:datamints_feuser/locallang_db.xml:tt_content.pi_flexform.redirect.doubleoptin_success</label>

--- a/locallang_db.xlf
+++ b/locallang_db.xlf
@@ -159,6 +159,9 @@
 			<trans-unit id="tt_content.pi_flexform.redirect.register_success" xml:space="preserve">
 				<source>Redirect Site ID &quot;Registration&quot;:</source>
 			</trans-unit>
+			<trans-unit id="tt_content.pi_flexform.redirect.doubleoptin" xml:space="preserve">
+				<source>Redirect Site ID &quot;Double Opt-in&quot; (fallback):</source>
+			</trans-unit>
 			<trans-unit id="tt_content.pi_flexform.redirect.doubleoptin_success" xml:space="preserve">
 				<source>Redirect Site ID &quot;Double Opt-in - Activated&quot;:</source>
 			</trans-unit>

--- a/locallang_db.xml
+++ b/locallang_db.xml
@@ -56,6 +56,7 @@
 			<label index="tt_content.pi_flexform.register.approvalcheck.doubleoptin">Double Opt-in</label>
 			<label index="tt_content.pi_flexform.register.approvalcheck.adminapproval">Admin approval</label>
 			<label index="tt_content.pi_flexform.redirect.register_success">Redirect Site ID &quot;Registration&quot;:</label>
+			<label index="tt_content.pi_flexform.redirect.doubleoptin">Redirect Site ID &quot;Double Opt-in&quot; (fallback):</label>
 			<label index="tt_content.pi_flexform.redirect.doubleoptin_success">Redirect Site ID &quot;Double Opt-in - Activated&quot;:</label>
 			<label index="tt_content.pi_flexform.redirect.doubleoptin_deleted">Redirect Site ID &quot;Double Opt-in - Denied&quot;:</label>
 			<label index="tt_content.pi_flexform.redirect.adminapproval_success">Redirect Site ID &quot;Admin Approval - Activated&quot;:</label>
@@ -124,6 +125,7 @@
 			<label index="tt_content.pi_flexform.register.approvalcheck.doubleoptin">Double-Opt-In</label>
 			<label index="tt_content.pi_flexform.register.approvalcheck.adminapproval">Administratorgenehmigung</label>
 			<label index="tt_content.pi_flexform.redirect.register_success">Weiterleitungsseiten ID &quot;Registrierung&quot;:</label>
+			<label index="tt_content.pi_flexform.redirect.doubleoptin">Weiterleitungsseiten ID "Double-Opt-In&quot; (Plan B):</label>
 			<label index="tt_content.pi_flexform.redirect.doubleoptin_success">Weiterleitungsseiten ID &quot;Double-Opt-In - Aktiviert&quot;:</label>
 			<label index="tt_content.pi_flexform.redirect.doubleoptin_deleted">Weiterleitungsseiten ID &quot;Double-Opt-In - Verweigert&quot;:</label>
 			<label index="tt_content.pi_flexform.redirect.adminapproval_success">Weiterleitungsseiten ID &quot;Administratorgenehmigung - Aktiviert&quot;:</label>


### PR DESCRIPTION
This solves two issues:
* The option was present in an older version of the extension. After upgrading it was still present in the flexform data and used by the code, but not visible and thus not editable in the plugin settings.
* The option is still used as fallback if no specific setting (doubleoptin_success or doubleoptin_deleted) is present and thus should be visible in the plugin settings.