### PR TITLE
[FEATURE] support TYPO3 subtree split with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,6 @@
         "php": ">=5.3.7,<=7.99.99",
         "typo3/cms-core": ">=6.2.0,<=8.99.990"
     },
-    "autoload": {
-        "psr-4": {
-            "Datamints\\Feuser\\": "Classes"
-        }
-    },
     "replace": {
         "datamints_feuser": "self.version",
         "typo3-ter/datamints_feuser": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "datamints/datamints_feuser",
+    "type": "typo3-cms-extension",
+    "description": "User registration and edit plugin, fully configurable, custom validators, autologin, double-opt-in, admin approval, IRRE configuration, resend activation mail, redirect features, support for saltedpasswords, support for salesforce. More to come!",
+    "license": "[GPL-2.0-or-later]",
+    "authors": [
+        {
+            "name": "Bernhard Baumgartl, datamints GmbH",
+            "email": "b.baumgartl@datamints.com"
+        }
+    ],
+    "require": {
+        "typo3/cms-core": ">=6.2.0,<9.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Datamints\\Feuser\\": "Classes/"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,19 +2,42 @@
     "name": "datamints/datamints_feuser",
     "type": "typo3-cms-extension",
     "description": "User registration and edit plugin, fully configurable, custom validators, autologin, double-opt-in, admin approval, IRRE configuration, resend activation mail, redirect features, support for saltedpasswords, support for salesforce. More to come!",
-    "license": "[GPL-2.0-or-later]",
+    "keywords": [
+        "feuser",
+        "Registration",
+        "edit",
+        "validators",
+        "autologin",
+        "double-opt-in",
+        "admin-approval",
+        "md5",
+        "salted",
+        "salesforce"
+    ],
+    "homepage": "https://extensions.typo3.org/extension/datamints_feuser/",
     "authors": [
         {
             "name": "Bernhard Baumgartl, datamints GmbH",
-            "email": "b.baumgartl@datamints.com"
+            "email": "b.baumgartl@datamints.com",
+            "role": "Developer",
+            "homepage": "https://www.datamints.com/"
         }
     ],
+    "license": "[GPL-2.0-or-later]",
+    "support": {
+        "issues": "http://forge.typo3.org/projects/extension-datamints_feuser"
+    },
     "require": {
-        "typo3/cms-core": ">=6.2.0,<9.0.0"
+        "php": ">=5.3.7,<=7.99.99",
+        "typo3/cms-core": ">=6.2.0,<=8.99.990"
     },
     "autoload": {
         "psr-4": {
-            "Datamints\\Feuser\\": "Classes/"
+            "Datamints\\Feuser\\": "Classes"
         }
+    },
+    "replace": {
+        "datamints_feuser": "self.version",
+        "typo3-ter/datamints_feuser": "self.version"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "datamints/datamints_feuser",
+    "name": "datamints/feuser",
     "type": "typo3-cms-extension",
     "description": "User registration and edit plugin, fully configurable, custom validators, autologin, double-opt-in, admin approval, IRRE configuration, resend activation mail, redirect features, support for saltedpasswords, support for salesforce. More to come!",
     "keywords": [
         "feuser",
-        "Registration",
+        "registration",
         "edit",
         "validators",
         "autologin",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,12 @@
         "php": ">=5.3.7,<=7.99.99",
         "typo3/cms-core": ">=6.2.0,<=8.99.990"
     },
+    "autoload": {
+        "classmap": [
+            "lib",
+            "pi1"
+        ]
+    },
     "replace": {
         "datamints_feuser": "self.version",
         "typo3-ter/datamints_feuser": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,6 @@
     },
     "replace": {
         "datamints_feuser": "self.version",
-        "typo3-ter/datamints_feuser": "self.version"
+        "typo3-ter/datamints-feuser": "self.version"
     }
 }


### PR DESCRIPTION
Datamints_feuser require the full typo3-cms package, this is bad if we want to use the TYPO3 subtree split with composer since TYPO3 8.7.10, to install only required packages. This will be mandatory in TYPO3 v9. (https://usetypo3.com/typo3-subtree-split-and-composer.html)

To support the TYPO3 subtree split, this PR add the necesarry composer.json wich requires only  the typo3/cms-core package. 

To get this fully work, please submit datamints_feuser to [packagist](https://packagist.org/packages/submit) after merge this PR or adding the necesarry composer.json. (I don't wont to submit forks of existing packages, like other users do)