### PR TITLE
remove bump_version.phar from composer install's

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes     export-ignore
+/bump_version.phar  export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,2 @@
-# Path-based git attributes
-# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
-
-# Ignore all test and documentation with "export-ignore".
-/.gitattributes     export-ignore
-/bump_version.phar  export-ignore
+/.gitattributes export-ignore
+/bump_version.phar export-ignore


### PR DESCRIPTION
The File bump_version.phar shouldn't be on our production.

more infos:
https://madewithlove.be/gitattributes/